### PR TITLE
Fixed the link to the example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ ie. This addresses Android QR crashes like:
 ## Example
 
 A working example of how to use this module can be found on Github at
-[https://github.com/acktie/Acktie-Mobile-QR-Example](https://github.com/acktie
-/Acktie-Mobile-QR-Example).
+[https://github.com/acktie/Acktie-Mobile-QR-Example](https://github.com/acktie/Acktie-Mobile-QR-Example).
 
 ## Description
 


### PR DESCRIPTION
The link to the example app contained an extra space that resulted in a 404.
